### PR TITLE
update GitHub project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author='Eduard Erja',
     author_email='eduard.erja@gmail.com',
-    url='https://github.com/eduarde/django_db_log',
+    url='https://github.com/eduarde/django-db-log',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
s/django_db_log/django-db-log/

It's a trivial change but without it the link from PyPI to the repository is broken so 
I figured still worth bringing to your attention. Feel free to just squash/fixup into your next regularly scheduled packaging update... :smile: 

Thanks for sharing your code!

p.s. if you have the freedom to do so, then in my experience, just renaming the GitHub project itself to snake case might be the simpler solution in the long run but I can't offer you a PR for that option.... :wink: 